### PR TITLE
:sparkles: :label: add adDisplayImageCropMessageText to PromoOptions …

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,6 +53,7 @@ export type PromoOptions = {
   setPromoData?: Dispatch<InputValues | null>;
   paymentType?: string;
   targetLinkIcons?: SocialsType;
+  adDisplayImageCropMessageText?: string;
 };
 export type ButtonFormElements = HTMLFormControlsCollection & {
   target: HTMLInputElement;


### PR DESCRIPTION
…type

This adds a missing type `adDisplayImageCropMessageText` originally added to the Promo Button internal types, which are being updated now (and therefore this missing type came to our knowledge). 