### PR TITLE
Feature/make how it works content props optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tincre/promo-types",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "MPL-2.0",
   "author": "Jason R. Stevens, CFA on behalf of Tincre <jason@tincre.com> (https://tincre.com)",
   "main": "dist/index.js",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,15 +14,15 @@ export type CloudinaryOptions = {
 };
 
 export type HowItWorksContent = {
-  steps: [
+  steps?: [
     { title: string; subtitle: string },
     { title: string; subtitle: string },
     { title: string; subtitle: string }
   ];
-  title: string;
-  subtitle: string;
-  submittedSubtitle: string;
-  submittedTitle: string;
+  title?: string;
+  subtitle?: string;
+  submittedSubtitle?: string;
+  submittedTitle?: string;
   footerCloseMessage?: string;
 };
 export type InputPlaceholders = InputValues & {};


### PR DESCRIPTION
This contributes to solving https://github.com/Tincre/promo-button/issues/202 by making the props for the type `HowItWorksContent` optional.